### PR TITLE
Remove unnecessary snmp-mibs-downloader package

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install tox tox-gh-actions coverage
-          sudo apt-get install -y --no-install-recommends snmp libsnmp-dev snmp-mibs-downloader
+          sudo apt-get install -y --no-install-recommends snmp libsnmp-dev
 
       - name: Test with tox
         run: tox


### PR DESCRIPTION
Zino vendors the MIB files it needs.