### PR TITLE
Let CFFI figure out timeval member types

### DIFF
--- a/src/netsnmpy/netsnmp_ffi.py
+++ b/src/netsnmpy/netsnmp_ffi.py
@@ -33,9 +33,11 @@ typedef unsigned short u_short;
 typedef unsigned char u_char;
 typedef unsigned int u_int;
 typedef unsigned long oid;
+typedef int... time_t;
+typedef int... suseconds_t;
 typedef struct timeval {{
-    long tv_sec;
-    long tv_usec;
+    time_t tv_sec;
+    suseconds_t tv_usec;
 }};
 
 


### PR DESCRIPTION
These typedefs should allow CFFI to figure out by itself which integer types are used for struct timeval members on the target platform.

Fixes #2 (maybe, I'll let @he32 test it first)