### PR TITLE
Force override ZIP files from artifacts

### DIFF
--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -33,7 +33,7 @@ jobs:
            do
              IFS=$'\t' read name url <<< "$artifact"
              gh api $url > "$name.zip"
-             unzip -d "$name" "$name.zip"
+             unzip -o -d "$name" "$name.zip"
            done
 
       - name: "Publish test results"


### PR DESCRIPTION
This can happen when for multiple python versions tests fail only on some.

When rerunning only these failing tests it leads to these files already existing and it waits for confirmation to override these files.
So we force this override so that this action doesn't fail.

Previously done in https://github.com/Uninett/Argus/pull/835 and https://github.com/Uninett/nav/pull/2975, but since this happened here now once as well I thought it might be good to introduce it. 

Example for this happening: https://github.com/Uninett/netsnmp-cffi/actions/runs/17263574293/job/48990440212