### PR TITLE
Add raw SNMP packet parsing for trap multiplexer support

### DIFF
--- a/changelog.d/+parse-raw-trap.added.md
+++ b/changelog.d/+parse-raw-trap.added.md
@@ -1,0 +1,1 @@
+Added `parse_raw_trap()` function to decode raw BER-encoded SNMP packets into `SNMPTrap` objects (for example, for use with SNMP trap multiplexers like straps/nmtrapd).

--- a/src/netsnmpy/netsnmp_ffi.py
+++ b/src/netsnmpy/netsnmp_ffi.py
@@ -258,6 +258,13 @@ netsnmp_session   *snmp_add(netsnmp_session *,
                             int (*fpost_parse) (netsnmp_session *,
                                                 netsnmp_pdu *, int));
 
+/* Function for parsing raw SNMP packets from bytes */
+int                snmp_parse(void *,
+                              netsnmp_session *,
+                              netsnmp_pdu *,
+                              u_char *,
+                              size_t);
+
 /* structs and functions required for parsing/decoding MIB information */
 struct enum_list {{
     struct enum_list *next;

--- a/src/netsnmpy/trapsession.py
+++ b/src/netsnmpy/trapsession.py
@@ -202,11 +202,25 @@ class SNMPTrap:
         )
 
     @classmethod
-    def from_pdu(cls, pdu: _ffi.CData) -> "SNMPTrap":
-        """Creates an SNMPTrap object from a Net-SNMP pdu structure."""
+    def from_pdu(
+        cls,
+        pdu: _ffi.CData,
+        source_override: Optional[IPAddress] = None,
+    ) -> "SNMPTrap":
+        """Creates an SNMPTrap object from a Net-SNMP pdu structure.
+
+        :param pdu: A pointer to a Net-SNMP pdu structure.
+        :param source_override: Optional source IP address to use instead of extracting the source
+            from the PDU's transport data.  This is useful when the PDU has been parsed from raw
+            bytes (e.g. from a trap multiplexer) where there is no transport data attached to the
+            PDU.
+        """
         variables = parse_response_variables(pdu[0])
 
-        source = cls.get_transport_addr(pdu)
+        if source_override is not None:
+            source = source_override
+        else:
+            source = cls.get_transport_addr(pdu)
         agent_addr = generic_type = trap_oid = uptime = None
         community = _ffi.string(pdu.community)
         try:
@@ -309,3 +323,32 @@ class SNMPTrap:
             generic_type, str(generic_type)
         ).upper()
         return snmp_trap_oid, generic_type
+
+
+def parse_raw_trap(data: bytes, source_addr: IPAddress) -> SNMPTrap:
+    """Parse a raw BER-encoded SNMP packet into an SNMPTrap.
+
+    This is useful for decoding trap packets received from an SNMP trap multiplexer
+    like straps/nmtrapd, where the raw SNMP packet bytes and the original source address
+    are provided separately.
+
+    :param data: Raw BER-encoded SNMP message bytes.
+    :param source_addr: Original trap sender IP address (e.g. from straps/nmtrapd header).
+    :return: A parsed SNMPTrap object.
+    :raises ValueError: If the SNMP packet cannot be parsed.
+    """
+    if not data:
+        raise ValueError("Cannot parse empty SNMP data")
+
+    sess = _ffi.new("netsnmp_session *")
+    _lib.snmp_sess_init(sess)
+
+    pdu = _lib.snmp_pdu_create(0)
+    try:
+        buf = _ffi.from_buffer("u_char[]", data)
+        rc = _lib.snmp_parse(_ffi.NULL, sess, pdu, buf, len(data))
+        if rc != 0:
+            raise ValueError(f"Failed to parse SNMP PDU (snmp_parse returned {rc})")
+        return SNMPTrap.from_pdu(pdu, source_override=ip_address(source_addr))
+    finally:
+        _lib.snmp_free_pdu(pdu)

--- a/tests/test_pdu_parse.py
+++ b/tests/test_pdu_parse.py
@@ -1,0 +1,54 @@
+"""Tests for parsing raw BER-encoded SNMP packets into SNMPTrap objects."""
+
+from ipaddress import IPv4Address, ip_address
+
+import pytest
+
+from netsnmpy.oids import OID
+from netsnmpy.trapsession import parse_raw_trap
+
+# A valid SNMPv2c trap PDU (coldStart with ifIndex.1=42, community=public, uptime=12345)
+# Built using pysnmp's protocol API and BER encoder.
+SNMPV2C_COLDSTART_TRAP = bytes.fromhex(
+    "305402010104067075626c6963a74702034ff374020100020100303a300e06082b060102010103004302"
+    "30393017060a2b06010603010104010006092b0601060301010501300f060a2b060102010202010101"
+    "02012a"
+)
+SOURCE_ADDR = ip_address("192.168.1.1")
+
+
+class TestParseRawTrap:
+    def test_when_parsing_valid_v2c_trap_then_source_should_use_override_address(self):
+        trap = parse_raw_trap(SNMPV2C_COLDSTART_TRAP, SOURCE_ADDR)
+        assert trap.source == IPv4Address("192.168.1.1")
+
+    def test_when_parsing_valid_v2c_trap_then_community_should_be_extracted(self):
+        trap = parse_raw_trap(SNMPV2C_COLDSTART_TRAP, SOURCE_ADDR)
+        assert trap.community == "public"
+
+    def test_when_parsing_valid_v2c_trap_then_version_should_be_2c(self):
+        trap = parse_raw_trap(SNMPV2C_COLDSTART_TRAP, SOURCE_ADDR)
+        assert trap.version == "2c"
+
+    def test_when_parsing_valid_v2c_trap_then_trap_oid_should_be_extracted(self):
+        trap = parse_raw_trap(SNMPV2C_COLDSTART_TRAP, SOURCE_ADDR)
+        assert trap.trap_oid == OID(".1.3.6.1.6.3.1.1.5.1")
+
+    def test_when_parsing_valid_v2c_trap_then_uptime_should_be_extracted(self):
+        trap = parse_raw_trap(SNMPV2C_COLDSTART_TRAP, SOURCE_ADDR)
+        assert trap.uptime == 12345
+
+    def test_when_parsing_valid_v2c_trap_then_varbinds_should_be_extracted(self):
+        trap = parse_raw_trap(SNMPV2C_COLDSTART_TRAP, SOURCE_ADDR)
+        assert len(trap.variables) == 1
+        oid, value = trap.variables[0]
+        assert oid == OID(".1.3.6.1.2.1.2.2.1.1.1")
+        assert value == 42
+
+    def test_given_malformed_data_then_parse_raw_trap_should_raise_value_error(self):
+        with pytest.raises(ValueError, match="Failed to parse SNMP PDU"):
+            parse_raw_trap(b"\x00\x01\x02\x03", SOURCE_ADDR)
+
+    def test_given_empty_data_then_parse_raw_trap_should_raise_value_error(self):
+        with pytest.raises(ValueError, match="Cannot parse empty SNMP data"):
+            parse_raw_trap(b"", SOURCE_ADDR)


### PR DESCRIPTION
## Scope and purpose

Adds the ability to parse raw BER-encoded SNMP packets into `SNMPTrap` objects, so that Zino 2 can receive traps from an SNMP trap multiplexer like straps/nmtrapd instead of binding directly to a UDP port (see Uninett/zino#362).

### This pull request
* Exposes Net-SNMP's `snmp_parse()` via the FFI layer
* Adds `parse_raw_trap()` convenience function in `trapsession.py`
* Adds `source_override` parameter to `SNMPTrap.from_pdu()` for PDUs without transport data

## Contributor Checklist

* [x] Added a changelog fragment for towncrier
* [x] Added/amended tests for new/changed code
* [x] ~~Added/changed documentation~~
* [x] Linted/formatted the code with ruff
* [x] The first line of the commit message continues the sentence "If applied, this commit will ...", starts with a capital letter, does not end with punctuation and is 50 characters or less long
* [ ] ~~If applicable: Created new issues if this PR does not fix the issue completely/there is further work to be done~~