### PR TITLE
Pin snmpsim to version that's not 1.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ test = [
     "pytest-asyncio",
     "pytest-cov",
     "retry",
-    "snmpsim>=1.0,!=1.1.6",
+    "snmpsim>=1.0,!=1.1.6,!=1.2.2",
     "pyasyncore; python_version >= '3.12'",
     "tox",
     "tox-uv",


### PR DESCRIPTION
The new release makes the tests fail since pysmi is now an optional dependency, but it is used in the code.