### PR TITLE
Make `struct enum_list` cdef flexible

### DIFF
--- a/changelog.d/23.fixed.md
+++ b/changelog.d/23.fixed.md
@@ -1,0 +1,1 @@
+Fix `ffi.error` from a size mismatch between the cdef and the real C layout of `struct enum_list`, by marking the cdef declaration as flexible. The mismatch caused crashes on platforms where CFFI verifies struct sizes against the C compiler (e.g. NetBSD/pkgsrc builds of net-snmp), any time MIB enumerations were looked up.

--- a/src/netsnmpy/netsnmp_ffi.py
+++ b/src/netsnmpy/netsnmp_ffi.py
@@ -270,6 +270,7 @@ struct enum_list {{
     struct enum_list *next;
     int             value;
     char           *label;
+    ...;
 }};
 
 struct tree {{


### PR DESCRIPTION
## Scope and purpose

Fixes #23.

The CFFI declaration of `struct enum_list` in `src/netsnmpy/netsnmp_ffi.py` listed three fields, but upstream net-snmp's `include/net-snmp/library/parse.h` defines a fourth (`int lineno`). On 64-bit platforms that's 24 vs. 32 bytes.

On builds where CFFI verifies the cdef's total struct size against the C compiler's view, this triggers `ffi.error: struct enum_list: wrong total size` the first time `get_enums_from_subtree()` is reached — breaking any SNMP polling that decodes enumerated INTEGER values. This was observed on NetBSD/pkgsrc; Linux builds happen not to hit the verification path for this struct.

Mark the struct flexible with a trailing `...;` so CFFI defers the layout to the real headers we compile against. This also keeps us resilient to future upstream additions to the struct.

### This pull request
* ~~adds/changes/removes a dependency~~
* ~~changes the API~~

## Contributor Checklist

* [x] Added a changelog fragment for towncrier
* [ ] ~~Added/amended tests for new/changed code~~ — the failure mode is a build-time/load-time CFFI size check against system headers; reproducing it in CI would require a platform whose net-snmp headers diverge from the build host's, which is out of scope for this fix.
* [ ] ~~Added/changed documentation~~ — internal cdef change, no user-facing surface.
* [x] Linted/formatted the code with ruff (pre-commit ran clean)
* [x] The first line of the commit message continues the sentence "If applied, this commit will ..."
* [ ] ~~Created new issues if this PR does not fix the issue completely~~

## Test plan

- Reproduced on NetBSD/pkgsrc (net-snmp from `/usr/pkg`, Python 3.12) via Zino 2's `sparsewalk` path; pre-fix produced the `ffi.error` from issue #23.
- Confirmed working on NetBSD after applying the patch — enum lookups succeed and polling proceeds normally.